### PR TITLE
Add editing time and day highlight

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.prolificinteractive:material-calendarview:2.0.1'
 }

--- a/src/main/java/com/example/misnenakane/MainActivity.kt
+++ b/src/main/java/com/example/misnenakane/MainActivity.kt
@@ -1,29 +1,87 @@
 package com.example.misnenakane
 
 import android.os.Bundle
-import android.widget.CalendarView
+import android.graphics.Color
+import android.widget.Toast
+import com.prolificinteractive.materialcalendarview.MaterialCalendarView
+import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.prolificinteractive.materialcalendarview.DayViewDecorator
+import com.prolificinteractive.materialcalendarview.DayViewFacade
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import java.util.Calendar
 
 class MainActivity : AppCompatActivity() {
     private val db = Firebase.firestore
+    private val intentDates = mutableSetOf<CalendarDay>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val calendarView = findViewById<CalendarView>(R.id.calendarView)
+        val calendarView = findViewById<MaterialCalendarView>(R.id.calendarView)
 
-        calendarView.setOnDateChangeListener { _, year, month, dayOfMonth ->
-            val dateKey = String.format("%04d-%02d-%02d", year, month + 1, dayOfMonth)
+        db.collection("nakane").addSnapshotListener { snapshot, _ ->
+            intentDates.clear()
+            snapshot?.documents?.forEach { doc ->
+                val parts = doc.id.split("-")
+                if (parts.size == 3) {
+                    val y = parts[0].toInt()
+                    val m = parts[1].toInt()
+                    val d = parts[2].toInt()
+                    intentDates.add(CalendarDay.from(y, m, d))
+                }
+            }
+            refreshDecorators(calendarView)
+        }
 
-            NakanaDialog(this, dateKey) { tekst ->
+        calendarView.setOnDateChangedListener { _, date, _ ->
+            val selectedCal = Calendar.getInstance().apply {
+                set(date.year, date.month - 1, date.day)
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+
+            val today = Calendar.getInstance().apply {
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+
+            if (selectedCal.before(today)) {
+                Toast.makeText(this, "Ne može se mijenjati prošli dan", Toast.LENGTH_SHORT).show()
+                return@setOnDateChangedListener
+            }
+
+            val dateKey = String.format("%04d-%02d-%02d", date.year, date.month, date.day)
+
+            NakanaDialog(this, dateKey) { tekst, sat ->
                 if (tekst.isNotBlank()) {
-                    val data = hashMapOf("tekst" to tekst)
+                    val data = hashMapOf<String, Any>("tekst" to tekst)
+                    sat?.let { data["sat"] = it }
                     db.collection("nakane").document(dateKey).set(data)
                 }
             }.show()
         }
+    }
+
+    private fun refreshDecorators(calendarView: MaterialCalendarView) {
+        calendarView.removeDecorators()
+        calendarView.addDecorator(object : DayViewDecorator {
+            override fun shouldDecorate(day: CalendarDay) = true
+            override fun decorate(view: DayViewFacade) {
+                view.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.parseColor("#CCFFCC")))
+            }
+        })
+        calendarView.addDecorator(object : DayViewDecorator {
+            override fun shouldDecorate(day: CalendarDay) = intentDates.contains(day)
+            override fun decorate(view: DayViewFacade) {
+                view.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.parseColor("#FFFF99")))
+            }
+        })
     }
 }

--- a/src/main/java/com/example/misnenakane/NakanaDialog.kt
+++ b/src/main/java/com/example/misnenakane/NakanaDialog.kt
@@ -7,23 +7,25 @@ import android.widget.EditText
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
-class NakanaDialog(context: Context, val datum: String, val onSave: (String) -> Unit) {
+class NakanaDialog(private val context: Context, val datum: String, val onSave: (String, String?) -> Unit) {
     private val db = Firebase.firestore
 
     fun show() {
         val inflater = LayoutInflater.from(context)
         val view = inflater.inflate(R.layout.dialog_nakana, null)
         val input = view.findViewById<EditText>(R.id.editTextNakana)
+        val timeInput = view.findViewById<EditText>(R.id.editTextSat)
 
         db.collection("nakane").document(datum).get().addOnSuccessListener {
             input.setText(it.getString("tekst") ?: "")
+            timeInput.setText(it.getString("sat") ?: "")
         }
 
         AlertDialog.Builder(context)
             .setTitle("Misna nakana za $datum")
             .setView(view)
             .setPositiveButton("Spremi") { _, _ ->
-                onSave(input.text.toString())
+                onSave(input.text.toString(), timeInput.text.toString().ifBlank { null })
             }
             .setNegativeButton("Odustani", null)
             .show()

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <CalendarView
+    <com.prolificinteractive.materialcalendarview.MaterialCalendarView
         android:id="@+id/calendarView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/src/main/res/layout/dialog_nakana.xml
+++ b/src/main/res/layout/dialog_nakana.xml
@@ -10,4 +10,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Upiši misnu nakanu" />
+
+    <EditText
+        android:id="@+id/editTextSat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Sat mise (npr. 18:30)"
+        android:inputType="time" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- switch to MaterialCalendarView
- color days with/without intentions
- allow editing intentions with optional time field
- prevent editing past dates
- add MaterialCalendarView dependency

## Testing
- `gradle build` *(fails: only buildscript {}, pluginManagement {} and other plugins {} script blocks are allowed before plugins {} blocks)*

------
https://chatgpt.com/codex/tasks/task_e_688d2a01483483288d1ed449f91d0023